### PR TITLE
Support extra resource table segments required for linux kernel 4.9 [ESD-1032]

### DIFF
--- a/lib/include/openamp/remoteproc.h
+++ b/lib/include/openamp/remoteproc.h
@@ -66,10 +66,10 @@
  */
 OPENAMP_PACKED_BEGIN
 struct resource_table {
-	unsigned int ver;
-	unsigned int num;
-	unsigned int reserved[2];
-	unsigned int offset[0];
+	uint32_t ver;
+	uint32_t num;
+	uint32_t reserved[2];
+	uint32_t offset[0];
 } OPENAMP_PACKED_END;
 
 /**
@@ -83,8 +83,8 @@ struct resource_table {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_hdr {
-	unsigned int type;
-	unsigned char data[0];
+	uint32_t type;
+	uint8_t data[0];
 } OPENAMP_PACKED_END;
 
 /**
@@ -112,7 +112,9 @@ enum fw_resource_type {
 	RSC_DEVMEM = 1,
 	RSC_TRACE = 2,
 	RSC_VDEV = 3,
-	RSC_LAST = 4,
+	RSC_RPROC_MEM = 4,
+	RSC_FW_CHKSUM = 5,
+	RSC_LAST = 6,
 };
 
 #define FW_RSC_ADDR_ANY (0xFFFFFFFFFFFFFFFF)
@@ -162,13 +164,13 @@ enum fw_resource_type {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_carveout {
-	unsigned int type;
-	unsigned int da;
-	unsigned int pa;
-	unsigned int len;
-	unsigned int flags;
-	unsigned int reserved;
-	unsigned char name[32];
+	uint32_t type;
+	uint32_t da;
+	uint32_t pa;
+	uint32_t len;
+	uint32_t flags;
+	uint32_t reserved;
+	uint8_t name[32];
 } OPENAMP_PACKED_END;
 
 /**
@@ -202,13 +204,13 @@ struct fw_rsc_carveout {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_devmem {
-	unsigned int type;
-	unsigned int da;
-	unsigned int pa;
-	unsigned int len;
-	unsigned int flags;
-	unsigned int reserved;
-	unsigned char name[32];
+	uint32_t type;
+	uint32_t da;
+	uint32_t pa;
+	uint32_t len;
+	uint32_t flags;
+	uint32_t reserved;
+	uint8_t name[32];
 } OPENAMP_PACKED_END;
 
 /**
@@ -229,11 +231,11 @@ struct fw_rsc_devmem {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_trace {
-	unsigned int type;
-	unsigned int da;
-	unsigned int len;
-	unsigned int reserved;
-	unsigned char name[32];
+	uint32_t type;
+	uint32_t da;
+	uint32_t len;
+	uint32_t reserved;
+	uint8_t name[32];
 } OPENAMP_PACKED_END;
 
 /**
@@ -255,11 +257,11 @@ struct fw_rsc_trace {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_vdev_vring {
-	unsigned int da;
-	unsigned int align;
-	unsigned int num;
-	unsigned int notifyid;
-	unsigned int reserved;
+	uint32_t da;
+	uint32_t align;
+	uint32_t num;
+	uint32_t notifyid;
+	uint32_t reserved;
 } OPENAMP_PACKED_END;
 
 /**
@@ -299,16 +301,54 @@ struct fw_rsc_vdev_vring {
  */
 OPENAMP_PACKED_BEGIN
 struct fw_rsc_vdev {
-	unsigned int type;
-	unsigned int id;
-	unsigned int notifyid;
-	unsigned int dfeatures;
-	unsigned int gfeatures;
-	unsigned int config_len;
-	unsigned char status;
-	unsigned char num_of_vrings;
-	unsigned char reserved[2];
+	uint32_t type;
+	uint32_t id;
+	uint32_t notifyid;
+	uint32_t dfeatures;
+	uint32_t gfeatures;
+	uint32_t config_len;
+	uint8_t status;
+	uint8_t num_of_vrings;
+	uint8_t reserved[2];
 	struct fw_rsc_vdev_vring vring[0];
+} OPENAMP_PACKED_END;
+
+/**
+ * struct fw_rsc_rproc_mem - remote processor memory
+ * @da: device address
+ * @pa: physical address
+ * @len: length (in bytes)
+ * @reserved: reserved (must be zero)
+ *
+ * This resource entry tells the host to the remote processor
+ * memory that the host can be used as shared memory.
+ *
+ * These request entries should precede other shared resource entries
+ * such as vdevs, vrings.
+ */
+OPENAMP_PACKED_BEGIN
+struct fw_rsc_rproc_mem {
+	uint32_t type;
+	uint32_t da;
+	uint32_t pa;
+	uint32_t len;
+	uint32_t reserved;
+} OPENAMP_PACKED_END;
+
+/*
+ * struct fw_rsc_fw_chksum - firmware checksum
+ * @algo: algorithm to generate the cheksum
+ * @chksum: checksum of the firmware loadable sections.
+ *
+ * This resource entry provides checksum for the firmware loadable sections.
+ * It is used to check if the remote already runs with the expected firmware to
+ * decide if it needs to start the remote if the remote is already running.
+ */
+OPENAMP_PACKED_BEGIN
+struct fw_rsc_fw_chksum {
+	uint32_t type;
+	uint8_t algo[16];
+	uint8_t chksum[64];
 } OPENAMP_PACKED_END;
 
 /**

--- a/lib/remoteproc/rsc_table_parser.c
+++ b/lib/remoteproc/rsc_table_parser.c
@@ -247,5 +247,5 @@ int handle_mmu_rsc(struct remote_proc *rproc, void *rsc)
 	(void)rproc;
 	(void)rsc;
 
-	return RPROC_ERR_RSC_TAB_NS;
+	return RPROC_SUCCESS;
 }


### PR DESCRIPTION
Linux kernel version > 4.6 require a newer open-amp version than we currently use. piksi_firmware_private actually makes very little use of open-amp functionality, but it does use various structures to export important information to the linux remoteproc driver via the ELF 'resource table'. It is in this resource table that things have changed, the newer kernel requires some extra information in the table which we currently don't write.

The best option would be to simply merge in upstream changes to open-amp, however there has been significant rework in the project, including the split of some components out in to libmetal. The build system has changed enough that merging it in to piksi_firmware_private is not a small task.

Since the only parts we actually require are some new struct definitions it seems the best solution is to cherry pick the changes to header files and leave a proper upgrade of the project to another day.

No specific testing is required for this change and it does not include any functional changes other than a single line which now returns a success code when it encounters one of the new resource table structures rather than an error as it did previously. Changes here can be verified during testing of other components simply by observing that a later linux kernel version with the newer version of remoteproc is able to start the private firmware on the second CPU core.